### PR TITLE
Make script (more) compatible for Windows users

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,4 +8,4 @@ source venv/bin/activate
 python src/analysis.py
 ```
 
-> **_NOTE:_**  Windows users should download the font "Linux Libertine O" or change it.
+> **_NOTE:_**  Windows users should download the font "Linux Libertine O" and hope for the best or change it to a system font.

--- a/README.md
+++ b/README.md
@@ -7,3 +7,5 @@ python -m venv venv #1st time only
 source venv/bin/activate
 python src/analysis.py
 ```
+
+> **_NOTE:_**  Windows users should download the font "Linux Libertine O" or change it.

--- a/src/analysis.py
+++ b/src/analysis.py
@@ -1,7 +1,8 @@
 import csv
 from collections import Counter
 import matplotlib.pyplot as plt
-plt.rcParams["font.family"] = ["Linux Libertine O", "serif"]
+# plt.rcParams["font.family"] = ["Linux Libertine O", "serif"] # Linuy
+plt.rcParams["font.family"] = ["Calibri", "serif"]  # Windows
 plt.rcParams["mathtext.fontset"] = "dejavuserif"
 plt.rcParams['lines.linewidth'] = 0.5
 plt.rcParams['axes.linewidth'] = 0.5

--- a/src/analysis.py
+++ b/src/analysis.py
@@ -65,7 +65,7 @@ def _flatten(l):
 
 
 data = []
-with open('data/Selection and Extraction sheet (SLR Green AI).xlsx - Data extraction CLEAN.csv') as csv_file:
+with open('data/Selection and Extraction sheet (SLR Green AI).xlsx - Data extraction CLEAN.csv', mode='r', encoding='utf-8') as csv_file:
     reader = csv.DictReader(csv_file, delimiter=',')
     for row in reader:
         row["topic_set"] = set(TOPIC_DICTIONARY.get(topic, topic)


### PR DESCRIPTION
I had some problems running `analysis.py` without using `..., mode='r', encoding='utf-8'` when opening the csv file. 

In addition, I made a duplicate entry for setting the font for the plots and added a comment at the end of the line. Even if the font "Linux Libertine O" is manually installed on a Windows machine, it may not work well. Finally, I added a note to the readme.